### PR TITLE
Don't build arm images for artful.

### DIFF
--- a/build_all.py
+++ b/build_all.py
@@ -28,7 +28,7 @@ SUPPORTED_TARGETS = {
     'ubuntu': {
         'trusty': ['i386', 'armhf'],
         'xenial': ALL_ARCHES,
-        'artful': ALL_ARCHES,
+        'artful': ['i386'],
         'bionic': ALL_ARCHES,
     }
 }


### PR DESCRIPTION
Short of building our own patched glibc for artful there's no resolution to https://github.com/osrf/multiarch-docker-image-generation/issues/17. Since we're not using these arm images on the buildfarm should we just drop them from the list of images we try to build?