### PR TITLE
Import bash-4.4.18-1ubuntu1osrf1 to fix qemu support.

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -74,6 +74,9 @@ if [[ ${foreign_arches[*]} =~ $arch ]]; then
   # dpkg doesn't seem able to override the exist status of a prerm script.
   if [ $suite == 'bionic' -a \( $arch == 'arm64' -o $arch == 'armhf' \) ]; then
     _bash_pkg="bash_4.4.18-1ubuntu1osrf1_${arch}.deb"
+    if [ ! -e $_bash_pkg ]; then
+      wget "https://github.com/osrf/multiarch-docker-image-generation/releases/download/bash-4.4.18-1ubuntu1osrf1/$_bash_pkg"
+    fi
     cp $_bash_pkg $chroot_dir/tmp/$_bash_pkg
     echo $(LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir /debootstrap/debootstrap --second-stage || true)
     LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir rm /var/lib/dpkg/info/bash.prerm

--- a/build-image.sh
+++ b/build-image.sh
@@ -68,7 +68,20 @@ if [[ ${foreign_arches[*]} =~ $arch ]]; then
   elif [ $arch == 'arm64' ]; then
     cp qemu-aarch64-static $chroot_dir/usr/bin/
   fi
-  LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir /debootstrap/debootstrap --second-stage
+  # Use a modified bash in arm bionic
+  # Workaround for https://github.com/osrf/multiarch-docker-image-generation/issues/18
+  # This is very hairy because bash's config scripts are all in bash and
+  # dpkg doesn't seem able to override the exist status of a prerm script.
+  if [ $suite == 'bionic' -a $arch == 'arm64' ]; then
+    _bash_pkg="bash_4.4.18-1ubuntu1osrf1_${arch}.deb"
+    cp $_bash_pkg $chroot_dir/tmp/$_bash_pkg
+    echo $(LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir /debootstrap/debootstrap --second-stage || true)
+    LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir rm /var/lib/dpkg/info/bash.prerm
+    LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir dpkg --purge --force-all bash
+    LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir dpkg -i /tmp/$_bash_pkg
+  else
+    LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir /debootstrap/debootstrap --second-stage
+  fi
   LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir dpkg --configure -a
 fi
 if [ $os == 'ubuntu' ]; then

--- a/build-image.sh
+++ b/build-image.sh
@@ -72,7 +72,7 @@ if [[ ${foreign_arches[*]} =~ $arch ]]; then
   # Workaround for https://github.com/osrf/multiarch-docker-image-generation/issues/18
   # This is very hairy because bash's config scripts are all in bash and
   # dpkg doesn't seem able to override the exist status of a prerm script.
-  if [ $suite == 'bionic' -a $arch == 'arm64' ]; then
+  if [ $suite == 'bionic' -a \( $arch == 'arm64' -o $arch == 'armhf' \) ]; then
     _bash_pkg="bash_4.4.18-1ubuntu1osrf1_${arch}.deb"
     cp $_bash_pkg $chroot_dir/tmp/$_bash_pkg
     echo $(LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir /debootstrap/debootstrap --second-stage || true)


### PR DESCRIPTION
Because bash is part of the core system the normal debootstrap command fails with upstream's latest version (#18). To get around that we've packaged bash with -no-pie and shoehorn it into
the chroot.

This takes some dirty doing because bash's installation and uninstallation hooks are written in bash, so if bash cannot run they fail and the package doesn't install. Circumventing this with a `dpkg --purge --force-all` is insufficient because a failure in the prerm hook will still stop uninstallation.
So we first remove the prerm script. This should do no lasting damage as we're immediately replacing bash and all it's files with a valid package.

I'm currently using generate_release_script.py from the buildfarm toolset to try and build melodic catkin debs locally against the test image `nuclearsandwich/ubuntu_arm64:bionic` on Docker Hub.

I also need set up an environment to build the armhf bash deb before I can add that case too, since my arm64 environment doesn't support armhf instructions.

I haven't yet uploaded the .deb that running this script now requires because I don't know how sensitive folks are to binary files in the repository. Obviously we're storing the static qemu binaries but that's a long-running part of the functionality and not a hopefully very temporary workaround. We could stick them right in, or store them in an orphan branch and add logic to the script to check them out which gets removed along with the orphan branch when they're no longer needed. Or I could just commit them and have that be that.