### PR TITLE
Add additional debian components on separate lines.

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -90,13 +90,22 @@ fi
 if [ $os == 'ubuntu' ]; then
   repositories='main restricted universe multiverse'
 else
-  repositories='main non-free contrib'
+  repositories='main'
+  additional_components='non-free contrib'
 fi
 
 ### update the list of package sources
 cat <<EOF > $chroot_dir/etc/apt/sources.list
 deb $apt_mirror $suite $repositories
 EOF
+
+if [ -n "$additional_components" ]; then
+	for component in $additional_components; do
+		cat <<EOF >> $chroot_dir/etc/apt/sources.list
+deb $apt_mirror $suite $component
+EOF
+	done
+fi
 
 if [ $os == 'ubuntu' ]; then
   cat <<EOF >> $chroot_dir/etc/apt/sources.list


### PR DESCRIPTION
The non-free and contrib components have been moved to separate lines to allow for easier addition or removal.

Resolves #22 by splitting the components up. Will also make them easier to remove if we decide to do so in #4.