### PR TITLE
Revert "Import bash-4.4.18-1ubuntu1osrf1 to fix qemu support."

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -68,23 +68,7 @@ if [[ ${foreign_arches[*]} =~ $arch ]]; then
   elif [ $arch == 'arm64' ]; then
     cp qemu-aarch64-static $chroot_dir/usr/bin/
   fi
-  # Use a modified bash in arm bionic
-  # Workaround for https://github.com/osrf/multiarch-docker-image-generation/issues/18
-  # This is very hairy because bash's config scripts are all in bash and
-  # dpkg doesn't seem able to override the exist status of a prerm script.
-  if [ $suite == 'bionic' -a \( $arch == 'arm64' -o $arch == 'armhf' \) ]; then
-    _bash_pkg="bash_4.4.18-1ubuntu1osrf1_${arch}.deb"
-    if [ ! -e $_bash_pkg ]; then
-      wget "https://github.com/osrf/multiarch-docker-image-generation/releases/download/bash-4.4.18-1ubuntu1osrf1/$_bash_pkg"
-    fi
-    cp $_bash_pkg $chroot_dir/tmp/$_bash_pkg
-    echo $(LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir /debootstrap/debootstrap --second-stage || true)
-    LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir rm /var/lib/dpkg/info/bash.prerm
-    LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir dpkg --purge --force-all bash
-    LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir dpkg -i /tmp/$_bash_pkg
-  else
-    LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir /debootstrap/debootstrap --second-stage
-  fi
+  LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir /debootstrap/debootstrap --second-stage
   LC_ALL=C LANGUAGE=C LANG=C chroot $chroot_dir dpkg --configure -a
 fi
 if [ $os == 'ubuntu' ]; then


### PR DESCRIPTION
Reverts osrf/multiarch-docker-image-generation#21 now that the upstream package works within qemu.

I'm going to make sure images can build with this branch and that the resulting image is suitable for building catkin, then we can get the deploy schedule together.