### PR TITLE
Add humanity-icon-theme to bionic images.

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -120,6 +120,13 @@ chmod +x $chroot_dir/usr/sbin/policy-rc.d
 # force dpkg not to call sync() after package extraction (speeding up installs)
 echo 'force-unsafe-io' > $chroot_dir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup
 
+# Install humanity-icon-theme on bionic to work around
+# https://github.com/ros-infrastructure/buildfarm_deployment/issues/198
+if [ $suite == 'bionic' ]; then
+	chroot $chroot_dir sh -c 'apt-get update && apt-get install -y humanity-icon-theme'
+fi
+
+
 # _keep_ us lean by effectively running "apt-get clean" after every install
 echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > $chroot_dir/etc/apt/apt.conf.d/docker-clean
 echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> $chroot_dir/etc/apt/apt.conf.d/docker-clean


### PR DESCRIPTION
Add humanity-icon-theme to base image ahead of time to work around a probable issue with Docker (described https://github.com/ros-infrastructure/buildfarm_deployment/issues/198)

This is a temporary fix and should not stick around for long.

I've run a few tests and this does seem to resolve the issues we have while unpacking this package on production agents.