### PR TITLE
Add Ubuntu 19.04 Disco to supported distributions

### DIFF
--- a/build_all.py
+++ b/build_all.py
@@ -30,6 +30,7 @@ SUPPORTED_TARGETS = {
         'xenial': ALL_ARCHES,
         'artful': ['i386'],
         'bionic': ALL_ARCHES,
+        'disco' : ALL_ARCHES,
     }
 }
 


### PR DESCRIPTION
For releasing the i386 versions of Ubuntu Disco in `build.osrfoundation.org` we would need support this distribution in the docker hub.