### PR TITLE
Add ubuntu focal docker images

### DIFF
--- a/build_all.py
+++ b/build_all.py
@@ -30,6 +30,7 @@ SUPPORTED_TARGETS = {
         'xenial': ALL_ARCHES,
         'bionic': ALL_ARCHES,
         'disco' : ALL_ARCHES,
+        'focal' : ALL_ARCHES,
     }
 }
 


### PR DESCRIPTION
I think this might be needed for http://build.ros.org/view/Nsrc_uF/job/Nbin_ufv8_uFv8__catkin__ubuntu_focal_arm64__binary/1/console .

```
00:00:14.077 # BEGIN SECTION: Check docker status
00:00:14.077 + echo Testing trivial docker invocation...
00:00:14.077 Testing trivial docker invocation...
00:00:14.077 + docker run --rm osrf/ubuntu_arm64:focal true
00:00:14.130 Unable to find image 'osrf/ubuntu_arm64:focal' locally
00:00:14.999 docker: Error response from daemon: manifest for osrf/ubuntu_arm64:focal not found: manifest unknown: manifest unknown.
```