### PR TITLE
Don't build i386 image for focal

### DIFF
--- a/build_all.py
+++ b/build_all.py
@@ -30,7 +30,7 @@ SUPPORTED_TARGETS = {
         'xenial': ALL_ARCHES,
         'bionic': ALL_ARCHES,
         'disco' : ALL_ARCHES,
-        'focal' : ALL_ARCHES,
+        'focal' : ['arm64', 'armhf'],
     }
 }
 


### PR DESCRIPTION
The i386 image for ubuntu focal doesn't build: https://github.com/osrf/multiarch-docker-image-generation/pull/32#issuecomment-575361402 . There [doesn't appear to be a `linux/386` option in the architectures for `ubuntu:focal`](https://hub.docker.com/layers/ubuntu/library/ubuntu/focal/images/sha256-d050ed7278c16ff627e4a70d7d353f1a2ec74d8a0b66e5a865356d92f5f6d87b). This PR removes it from the list of images to build.