### PR TITLE
Wrap semop() call so it syscalls semop() instead of semtimedop().

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -153,6 +153,12 @@ fi
 chroot $chroot_dir dpkg-divert --local --rename --add /sbin/initctl
 chroot $chroot_dir ln -sf /bin/true /sbin/initctl
 
+### Build semop wrapper
+cp wrap_semop.c $chroot_dir/tmp/
+chroot $chroot_dir apt-get -y install build-essential
+chroot $chroot_dir gcc -fPIC -shared -o /opt/libpreload-semop.so /tmp/wrap_semop.c
+chroot $chroot_dir printf /opt/libpreload-semop.so > $chroot_dir/etc/ld.so.preload
+
 ### cleanup and unmount /proc
 chroot $chroot_dir apt-get autoclean
 chroot $chroot_dir apt-get clean

--- a/build-image.sh
+++ b/build-image.sh
@@ -157,7 +157,7 @@ chroot $chroot_dir ln -sf /bin/true /sbin/initctl
 cp wrap_semop.c $chroot_dir/tmp/
 chroot $chroot_dir apt-get -y install build-essential
 chroot $chroot_dir gcc -fPIC -shared -o /opt/libpreload-semop.so /tmp/wrap_semop.c
-chroot $chroot_dir printf /opt/libpreload-semop.so > $chroot_dir/etc/ld.so.preload
+chroot $chroot_dir echo /opt/libpreload-semop.so > $chroot_dir/etc/ld.so.preload
 
 ### cleanup and unmount /proc
 chroot $chroot_dir apt-get autoclean

--- a/wrap_semop.c
+++ b/wrap_semop.c
@@ -1,9 +1,7 @@
 #include <unistd.h>
 #include <asm/unistd.h>
 #include <sys/syscall.h>
-
-/* Forward declare to avoid compiler warning */
-struct sembuf;
+#include <linux/sem.h>
 
 /* glibc 2.31 wraps semop() as a call to semtimedop() with the timespec set to NULL
  * qemu 3.1 doesn't support semtimedop(), so this wrapper syscalls the real semop()

--- a/wrap_semop.c
+++ b/wrap_semop.c
@@ -1,0 +1,14 @@
+#include <unistd.h>
+#include <asm/unistd.h>
+#include <sys/syscall.h>
+
+/* Forward declare to avoid compiler warning */
+struct sembuf;
+
+/* glibc 2.31 wraps semop() as a call to semtimedop() with the timespec set to NULL
+ * qemu 3.1 doesn't support semtimedop(), so this wrapper syscalls the real semop()
+ */
+int semop(int semid, struct sembuf *sops, unsigned nsops)
+{
+  return syscall(__NR_semop, semid, sops, nsops);
+}


### PR DESCRIPTION
Fixes #36

This works around glibc 2.31 wrapping `semop()` as a syscall to `semtimedop()`, which qemu does not support, by adding a library to `/etc/ld.so.preload` that wraps `semop()` as a syscall to `semop()`.