### PR TITLE
Add an LD_PRELOAD wrapper for *time64 syscalls.

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -159,6 +159,12 @@ chroot $chroot_dir apt-get -y install build-essential
 chroot $chroot_dir gcc -fPIC -shared -o /opt/libpreload-semop.so /tmp/wrap_semop.c
 chroot $chroot_dir echo /opt/libpreload-semop.so > $chroot_dir/etc/ld.so.preload
 
+### Build *time64 wrapper
+cp wrap_time64.c $chroot_dir/tmp/
+chroot $chroot_dir apt-get -y install build-essential
+chroot $chroot_dir gcc -fPIC -shared -o /opt/libpreload-time64.so /tmp/wrap_time64.c
+chroot $chroot_dir echo /opt/libpreload-time64.so >> $chroot_dir/etc/ld.so.preload
+
 ### cleanup and unmount /proc
 chroot $chroot_dir apt-get autoclean
 chroot $chroot_dir apt-get clean

--- a/wrap_time64.c
+++ b/wrap_time64.c
@@ -1,0 +1,9 @@
+#include <unistd.h>
+#include <asm/unistd.h>
+#include <sys/syscall.h>
+#include <time.h>
+
+int futimens(int fd, const struct timespec tsp[2])
+{
+    return syscall(__NR_utimensat, fd, NULL, &tsp[0], 0);
+}

--- a/wrap_time64.c
+++ b/wrap_time64.c
@@ -7,3 +7,8 @@ int futimens(int fd, const struct timespec tsp[2])
 {
     return syscall(__NR_utimensat, fd, NULL, &tsp[0], 0);
 }
+
+int clock_gettime(clockid_t clock_id, struct timespec *sp)
+{
+    return syscall(__NR_clock_gettime, clock_id, sp);
+}


### PR DESCRIPTION
In theory this should allow newer Focal containers to run on
older Xenial kernels.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@nuclearsandwich FYI

May solve #38, but needs testing and maybe some work to confirm.